### PR TITLE
Allow exclude of subchecks and update manifest

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,26 +1,35 @@
 ---
 user: allenporter
+checks:
+  exclude:
+  # Avoid unnecessary API usage after initial setup
+  - github
 repos:
 - name: k8s-gitops
-  exclude:
-  - setupcfg
-  - worktree # TODO: Add ability to exclude subjects (setupcfg)
+  checks:
+    exclude:
+    - setuppy
+    - setupcfg
 - name: ical
-  exclude: 
-    - worktree  # TODO: Enable flake8 conformance
+  checks:
+    exclude:
+    - setupcfg  # TODO: Enable flake8 conformance
 - name: pyrainbird
-  exclude: 
-    - worktree  # TODO: Needs github URL fixed
+  checks:
+    exclude:
+    - setupcfg  # TODO: Needs github URL fixed
 - name: gcal_sync
-  exclude: 
-    - worktree  # TODO: Enable flake8 conformance
+  checks:
+    exclude:
+    - setupcfg  # TODO: Enable flake8 conformance
 - name: flux-local
 - name: python-google-nest-sdm
-  exclude: 
-    - worktree  # TODO: Enable non-minimal setup.py
+  checks:
+    exclude:
+    - setuppy
+    - setupcfg  # TODO: Does not have metadata
 - name: hostdb
-  exclude: 
-    - worktree  # TODO: Enable flake8 conformance
+  checks:
+    exclude:
+    - setupcfg  # TODO: Enable flake8 conformance
 - name: repo-conformance
-exclude:
-- github

--- a/repo_conformance/check.py
+++ b/repo_conformance/check.py
@@ -83,14 +83,13 @@ class CheckAction:
         for r in manifest.repos:
             if repo and r.name != repo:
                 continue
-            errors.extend(
-                [
-                    fail.of(r.name)
-                    for fail in REPO_CHECKS.run_checks(
-                        r, exclude_checks=set(exclude + r.exclude) - set(include)
-                    )
-                ]
+            if not r.user:
+                r.user = manifest.user
+            r.checks.exclude = list(
+                (set(r.checks.exclude) | set(manifest.checks.exclude) | set(exclude)) - set(include)
             )
+
+            errors.extend([fail.of(r.name) for fail in REPO_CHECKS.run_checks(r, None)])
         if errors:
             print_errors(errors)
             sys.exit(1)

--- a/repo_conformance/checks/__init__.py
+++ b/repo_conformance/checks/__init__.py
@@ -1,3 +1,3 @@
 """Conformance checks module."""
 
-from . import github, worktree, setupcfg  # noqa
+from . import github, worktree, setupcfg, setuppy  # noqa

--- a/repo_conformance/checks/github.py
+++ b/repo_conformance/checks/github.py
@@ -13,7 +13,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @REPO_CHECKS.register()
-def github(repo: Repo) -> None:
+def github(repo: Repo, context: None) -> None:
     """Verify the github repository configuration via the github API."""
 
     github = Github()

--- a/repo_conformance/checks/registries.py
+++ b/repo_conformance/checks/registries.py
@@ -1,27 +1,12 @@
 """Conformance test registries."""
 
 import pathlib
-from dataclasses import dataclass
 
-from repo_conformance.manifest import Repo
 from repo_conformance.registry import CheckRegistry
 
 
-REPO_CHECKS = CheckRegistry[Repo]()
+REPO_CHECKS = CheckRegistry[None]()
 """Root conformance test registry for a manifest.Repo."""
 
-
-@dataclass
-class WorktreeSpec:
-    """Input for a worktree based confromance test."""
-
-    repo: Repo
-    worktree: pathlib.Path
-
-    def __str__(self) -> str:
-        """Human readable name for conformance errors."""
-        return str(self.repo)
-
-
-WORKTREE_CHECKS = CheckRegistry[WorktreeSpec]()
+WORKTREE_CHECKS = CheckRegistry[pathlib.Path]()
 """Conformance check registry for a repository github working tree."""

--- a/repo_conformance/checks/setuppy.py
+++ b/repo_conformance/checks/setuppy.py
@@ -1,0 +1,26 @@
+"""Verify python project setup.py conformance."""
+
+import configparser
+import logging
+import pathlib
+
+from repo_conformance.exceptions import CheckError
+from repo_conformance.manifest import Repo
+
+from .registries import WORKTREE_CHECKS
+
+
+@WORKTREE_CHECKS.register()
+def setuppy(repo: Repo, worktree: pathlib.Path) -> None:
+    """Verify python project setup.py conformance."""
+
+    # Verify minimal use of setup.py
+    setuppy = worktree / "setup.py"
+    if not setuppy.exists():
+        raise CheckError("Repo has no setup.py")
+
+    contents = setuppy.read_text()
+    if "setup()" not in contents:
+        if "setup(" in contents:
+            raise CheckError("Repo has setup.py that is not minimal")
+        raise CheckError("Repo setup.py does not contain setup()")

--- a/repo_conformance/checks/worktree.py
+++ b/repo_conformance/checks/worktree.py
@@ -11,7 +11,7 @@ import git
 from repo_conformance.exceptions import CheckError
 from repo_conformance.manifest import Repo
 
-from .registries import REPO_CHECKS, WORKTREE_CHECKS, WorktreeSpec
+from .registries import REPO_CHECKS, WORKTREE_CHECKS
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -48,11 +48,10 @@ def repo_worktree(repo: Repo) -> Generator[pathlib.Path, None, None]:
 
 
 @REPO_CHECKS.register()
-def worktree(repo: Repo) -> None:
+def worktree(repo: Repo, target: None) -> None:
     """Run conformance tests on the github worktree."""
 
     with repo_worktree(repo) as worktree:
-        spec = WorktreeSpec(repo=repo, worktree=worktree)
-        errors = WORKTREE_CHECKS.run_checks(spec)
+        errors = WORKTREE_CHECKS.run_checks(repo, context=worktree)
         if errors:
             raise CheckError(errors)

--- a/repo_conformance/exceptions.py
+++ b/repo_conformance/exceptions.py
@@ -39,3 +39,7 @@ class CheckError(Exception):
     def errors(self) -> list[Failure]:
         """Return underlying conformance errors."""
         return self._errors
+
+
+class ManifestError(Exception):
+    """An error parsing the manifest."""


### PR DESCRIPTION
Allow exclude of subchecks and update manifest to be more specific about which subcheck is failing. Split the python setup subchecks into separate checks.