### PR TITLE
Update ruff conformance tests to check for precommit check arguments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,11 @@ repos:
     args:
     - --allow-multiple-documents
   - id: check-added-large-files
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  rev: 'v0.0.256'
+  hooks:
+  - id: ruff
+    args: [--fix, --exit-non-zero-on-fix]
 - repo: https://github.com/codespell-project/codespell
   rev: v2.2.4
   hooks:
@@ -33,7 +38,3 @@ repos:
     types: [python]
     require_serial: true
     files: ^(flux_local/|tests/)
-- repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: 'v0.0.256'
-  hooks:
-  - id: ruff

--- a/README.md
+++ b/README.md
@@ -8,3 +8,31 @@ Conformance tests for all of my git repositories.
 $ python3 -m venv venv
 $ source venv/bin/activate
 ```
+
+## Usage
+
+The `repo` tool uses a `manifest.yaml` to describe all the git repos in scope.
+
+The `repo list` command verifies the manifest file can be parsed correctly:
+```
+$ repo list
+name: pyrainbird user: allenporter
+name: flux-local user: allenporter
+name: repo-conformance user: allenporter
+```
+
+Running conformance checks can be done with the `repo check` command:
+```
+$ repo check
+pyrainbird:
+  worktree:
+    ruff: Found flake8 config in setup.cfg; switch to ruff
+
+flux-local:
+  worktree:
+    ruff: Ruff hooks configuration mismatch:
+  - id: ruff
++   args:
++   - --fix
++   - --exit-non-zero-on-fix
+```


### PR DESCRIPTION
Update ruff conformance tests to check for precommit check arguments which automatically fix errors.