### PR TITLE
Add renovate conformance tests

### DIFF
--- a/repo_conformance/checks/__init__.py
+++ b/repo_conformance/checks/__init__.py
@@ -1,3 +1,4 @@
 """Conformance checks module."""
 
 from . import github, worktree, setupcfg, setuppy, flake8, ruff  # noqa
+from . import renovate  # noqa

--- a/repo_conformance/checks/renovate.py
+++ b/repo_conformance/checks/renovate.py
@@ -1,0 +1,60 @@
+"""Verify renovate conformance."""
+
+import difflib
+import logging
+import pathlib
+import json
+import json5
+
+from repo_conformance.exceptions import CheckError
+from repo_conformance.manifest import Repo
+
+from .registries import WORKTREE_CHECKS
+
+
+_LOGGER = logging.getLogger(__name__)
+
+PRE_COMMIT_URL = "https://github.com/charliermarsh/ruff-pre-commit"
+EXTENDS = "extends"
+EXPECTED_EXTENDS = [
+    "config:base",
+]
+PRECOMMIT = "pre-commit"
+EXPECTED_PRECOMMIT = {"enabled": True}
+
+
+@WORKTREE_CHECKS.register()
+def renovate(repo: Repo, worktree: pathlib.Path) -> None:
+    """Verify renovate conformance."""
+
+    plain_config_file = worktree / "renovate.json"
+    if plain_config_file.exists():
+        raise CheckError("Found renovate.json but prefer renovate.json5")
+
+    config_file = worktree / "renovate.json5"
+    if not config_file.exists():
+        raise CheckError("No renovate.json5 configuration file found")
+
+    renovate = json5.loads(config_file.read_text())
+
+    extends = renovate.get(EXTENDS, [])
+    if extends != EXPECTED_EXTENDS:
+        diff = "\n".join(
+            difflib.ndiff(
+                json.dumps({EXTENDS: extends}, sort_keys=False).split("\n"),
+                json.dumps({EXTENDS: EXPECTED_EXTENDS}, sort_keys=False).split("\n"),
+            )
+        )
+        raise CheckError(f"Renovate 'extends' configuration mismatch:\n{diff}")
+
+    precommit = renovate.get(PRECOMMIT, [])
+    if precommit != EXPECTED_PRECOMMIT:
+        diff = "\n".join(
+            difflib.ndiff(
+                json.dumps({PRECOMMIT: precommit}, sort_keys=False).split("\n"),
+                json.dumps({PRECOMMIT: EXPECTED_PRECOMMIT}, sort_keys=False).split(
+                    "\n"
+                ),
+            )
+        )
+        raise CheckError(f"Renovate 'pre-commit' configuration mismatch:\n{diff}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 -e .
 black==23.1.0
 coverage==7.2.2
+json5==0.9.11
 GitPython==3.1.31
 mypy==1.1.1
 pdoc==13.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ install_requires =
   PyYAML>=6.0
   pydantic>=1.10.6
   PyGithub>=1.58.0
+  json5>=0.9.11
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
Add renovate conformance tests that have only the most basic checks:
- we're using json5
- we have pre-commit enabled