### PR TITLE
Update ruff checks to verify workflows

### DIFF
--- a/repo_conformance/checks/renovate.py
+++ b/repo_conformance/checks/renovate.py
@@ -73,5 +73,5 @@ def renovate(repo: Repo, worktree: pathlib.Path) -> None:
     if "assignees" not in renovate:
         raise CheckError("Renovate had no default 'assignees' field")
 
-    if not renovate.get("dependencyDashboard"):
-        raise CheckError("Renovate 'dependencyDashboard' is not configured")
+    if "dependencyDashboard" in renovate:
+        raise CheckError("Renovate 'dependencyDashboard' is unnecessary")

--- a/repo_conformance/checks/ruff.py
+++ b/repo_conformance/checks/ruff.py
@@ -93,3 +93,14 @@ def ruff(repo: Repo, worktree: pathlib.Path) -> None:
                 raise CheckError(
                     f"Found unwanted {dep} dependencies in renovate config"
                 )
+
+    _LOGGER.debug("Checking workflows for unwanted deps %s", AVOID_DEPS)
+    workflow_files = worktree.glob(".github/workflows/*")
+    workflows = [req.read_text() for req in workflow_files]
+    for dep in WANT_DEPS:
+        if not any(dep in content for content in workflows):
+            raise CheckError(f"Missing {dep} dependencies in workflows files")
+    for dep in AVOID_DEPS:
+        if any(dep in content for content in workflows):
+            raise CheckError(f"Found unwanted {dep} dependencies in workflows files")
+


### PR DESCRIPTION
Update ruff checks to look for stale dependencies in workflows (caught issues in existing repos). Also cleanup the renovate config which is no longer needed given `config:base`.